### PR TITLE
make the projects build on Windows7 (powershell and maven 3.1)

### DIFF
--- a/calabash/pom.xml
+++ b/calabash/pom.xml
@@ -124,7 +124,7 @@
                   <fileset dir="${calabash.tmp.dir}">
                     <include name="xmlcalabash1-*/**/*" />
                   </fileset>
-                  <mapper type="regexp" from="^xmlcalabash1-[^/]*/(.*)" to="\1" />
+                  <mapper type="regexp" from="^xmlcalabash1-[^/\\]*[/\\](.*)" to="\1" />
                 </move>
                 <property name="ant.build.javac.source" value="1.5" />
                 <property name="ant.build.javac.target" value="1.5" />

--- a/jing/pom.xml
+++ b/jing/pom.xml
@@ -14,6 +14,10 @@
   <artifactId>jing</artifactId>
   <version>20120724.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
+  
+  <properties>
+	<jing.ant>ant</jing.ant>
+  </properties>
 
   <name>Jing</name>
   <description>Jing - tool for validating RelaxNG - (OSGi-compatible version)</description>
@@ -136,7 +140,7 @@
             </execution>
           </executions>
           <configuration>
-            <executable>${project.build.directory}/checkout/ant</executable>
+            <executable>${project.build.directory}/checkout/${jing.ant}</executable>
             <workingDirectory>${project.build.directory}/checkout</workingDirectory>
           </configuration>
         </plugin>
@@ -239,7 +243,7 @@
               </execution>
             </executions>
             <configuration>
-              <executable>${project.build.directory}/checkout/ant</executable>
+              <executable>${project.build.directory}/checkout/${jing.ant}</executable>
               <commandlineArgs>jing-dist</commandlineArgs>
               <workingDirectory>${project.build.directory}/checkout</workingDirectory>
             </configuration>
@@ -285,6 +289,17 @@
         </plugins>
       </build>
     </profile>
+	<profile>
+		<activation>
+			<os>
+				<family>Windows</family>
+			</os>
+		</activation>
+		<properties>
+			<jing.ant>ant.bat</jing.ant>
+		</properties>
+	</profile>
+	
   </profiles>
 
 </project>

--- a/jstyleparser/pom.xml
+++ b/jstyleparser/pom.xml
@@ -121,6 +121,7 @@
         <artifactId>maven-patch-plugin</artifactId>
         <version>1.1.1</version>
         <configuration>
+		  <optimizations>false</optimizations>
           <patchDirectory>src/main/patches</patchDirectory>
           <patches>
             <patch>uri_resolver.patch</patch>


### PR DESCRIPTION
make sure "cd osgi-libs && mvn clean install" work on Windows7. There are still issues with multiple goals such as "mvn compile install" that locks a few files and doesn't release the lock before executing the other goals.
