### PR TITLE
Update Calabash to 1.0.23 + patch

### DIFF
--- a/calabash/javadoc.xml
+++ b/calabash/javadoc.xml
@@ -1,18 +1,13 @@
 <?xml version="1.0"?>
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
-  <id>sources</id>
+  <id>javadoc</id>
   <includeBaseDirectory>false</includeBaseDirectory>
   <formats>
     <format>jar</format>
   </formats>
   <fileSets>
     <fileSet>
-      <directory>${project.build.directory}/sources/src</directory>
-      <outputDirectory>/</outputDirectory>
-      <useDefaultExcludes>true</useDefaultExcludes>
-    </fileSet>
-    <fileSet>
-      <directory>${project.build.directory}/sources/resources</directory>
+      <directory>${project.build.directory}/javadoc</directory>
       <outputDirectory>/</outputDirectory>
       <useDefaultExcludes>true</useDefaultExcludes>
     </fileSet>

--- a/calabash/pom.xml
+++ b/calabash/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.daisy.libs</groupId>
   <artifactId>com.xmlcalabash</artifactId>
-  <version>1.0.23-SNAPSHOT</version>
+  <version>1.0.23</version>
   <packaging>jar</packaging>
 
   <name>XML Calabash</name>
@@ -107,7 +107,7 @@
 
   <scm>
     <connection>scm:git:https://github.com/ndw/xmlcalabash1.git</connection>
-    <tag>${calabash.tag}</tag>
+    <tag>com.xmlcalabash-1.0.23</tag>
   </scm>
 
   <build>
@@ -236,33 +236,33 @@
                   <target>
                     <path id="build.classpath">
                       <fileset dir="${sources.dir}/lib">
-                        <include name="*.jar"/>
+                        <include name="*.jar" />
                       </fileset>
-                      <!-- <pathelement location="${sources.dir}/lib"/> -->
+                      <!-- <pathelement location="${sources.dir}/lib" /> -->
                     </path>
                     <javadoc destdir="${project.build.directory}/javadoc" classpathref="build.classpath">
                       <fileset dir="${sources.dir}/src" defaultexcludes="yes">
-                        <include name="**"/>
-                        <exclude name="com/xmlcalabash/extensions/MetadataExtractor.java"/>
-                        <exclude name="com/xmlcalabash/extensions/DiTAA.java"/>
-                        <exclude name="com/xmlcalabash/extensions/PlantUML.java"/>
-                        <exclude name="com/xmlcalabash/extensions/DeltaXML.java"/>
-                        <exclude name="com/xmlcalabash/extensions/SendMail.java"/>
-                        <exclude name="com/xmlcalabash/extensions/xmlunit/Compare.java"/>
-                        <exclude name="com/xmlcalabash/extensions/marklogic/XCCAdhocQuery.java"/>
-                        <exclude name="com/xmlcalabash/extensions/marklogic/XCCInsertDocument.java"/>
-                        <exclude name="com/xmlcalabash/extensions/marklogic/XCCInvokeModule.java"/>
-                        <exclude name="com/xmlcalabash/extensions/Sparql.java"/>
-                        <exclude name="com/xmlcalabash/extensions/RDFa.java"/>
-                        <exclude name="com/xmlcalabash/extensions/RDFLoad.java"/>
-                        <exclude name="com/xmlcalabash/extensions/RDFStep.java"/>
-                        <exclude name="com/xmlcalabash/extensions/RDFStore.java"/>
-                        <exclude name="com/xmlcalabash/util/FoXEP.java"/>
-                        <exclude name="com/xmlcalabash/util/FoFOP.java"/>
-                        <exclude name="com/xmlcalabash/util/FoAH.java"/>
-                        <exclude name="com/xmlcalabash/util/CssAH.java"/>
-                        <exclude name="com/xmlcalabash/util/CssPrince.java"/>
-                        <exclude name="com/xmlcalabash/drivers/SaxonProblem.java"/>
+                        <include name="**" />
+                        <exclude name="com/xmlcalabash/extensions/MetadataExtractor.java" />
+                        <exclude name="com/xmlcalabash/extensions/DiTAA.java" />
+                        <exclude name="com/xmlcalabash/extensions/PlantUML.java" />
+                        <exclude name="com/xmlcalabash/extensions/DeltaXML.java" />
+                        <exclude name="com/xmlcalabash/extensions/SendMail.java" />
+                        <exclude name="com/xmlcalabash/extensions/xmlunit/Compare.java" />
+                        <exclude name="com/xmlcalabash/extensions/marklogic/XCCAdhocQuery.java" />
+                        <exclude name="com/xmlcalabash/extensions/marklogic/XCCInsertDocument.java" />
+                        <exclude name="com/xmlcalabash/extensions/marklogic/XCCInvokeModule.java" />
+                        <exclude name="com/xmlcalabash/extensions/Sparql.java" />
+                        <exclude name="com/xmlcalabash/extensions/RDFa.java" />
+                        <exclude name="com/xmlcalabash/extensions/RDFLoad.java" />
+                        <exclude name="com/xmlcalabash/extensions/RDFStep.java" />
+                        <exclude name="com/xmlcalabash/extensions/RDFStore.java" />
+                        <exclude name="com/xmlcalabash/util/FoXEP.java" />
+                        <exclude name="com/xmlcalabash/util/FoFOP.java" />
+                        <exclude name="com/xmlcalabash/util/FoAH.java" />
+                        <exclude name="com/xmlcalabash/util/CssAH.java" />
+                        <exclude name="com/xmlcalabash/util/CssPrince.java" />
+                        <exclude name="com/xmlcalabash/drivers/SaxonProblem.java" />
                       </fileset>
                     </javadoc>
                   </target>

--- a/calabash/pom.xml
+++ b/calabash/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.daisy.libs</groupId>
   <artifactId>com.xmlcalabash</artifactId>
-  <version>1.0.18-p1-SNAPSHOT</version>
+  <version>1.0.23-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>XML Calabash</name>
@@ -29,19 +29,33 @@
   </licenses>
 
   <properties>
-    <calabash.source.url>https://github.com/ndw/xmlcalabash1/archive/v1.0.18.95.zip</calabash.source.url>
+    <calabash.tag>v1.0.23.95</calabash.tag>
+    <sources.dir>${basedir}/target/sources</sources.dir>
   </properties>
 
   <dependencies>
+    <!-- required -->
     <dependency>
       <groupId>net.sf.saxon</groupId>
       <artifactId>Saxon-HE</artifactId>
-      <version>9.5.1-5</version>
+      <version>9.5.1-8</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.2.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.7</version>
+    </dependency>
+    <!-- optional -->
+    <dependency>
+      <groupId>commons-fileupload</groupId>
+      <artifactId>commons-fileupload</artifactId>
+      <version>1.3.1</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.thaiopensource</groupId>
@@ -59,12 +73,18 @@
         </exclusion>
       </exclusions>
     </dependency>
-	<dependency>
-	    <groupId>javax.mail</groupId>
-	    <artifactId>javax.mail-api</artifactId>
-	    <version>1.4.5</version>
+    <dependency>
+      <groupId>javax.mail</groupId>
+      <artifactId>javax.mail-api</artifactId>
+      <version>1.4.5</version>
       <optional>true</optional>
-	</dependency>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ant</groupId>
+      <artifactId>ant</artifactId>
+      <version>1.8.4</version>
+      <optional>true</optional>
+    </dependency>
     <dependency>
       <groupId>org.ccil.cowan.tagsoup</groupId>
       <artifactId>tagsoup</artifactId>
@@ -77,16 +97,21 @@
       <version>1.4</version>
       <optional>true</optional>
     </dependency>
-	<dependency>
-	    <groupId>xmlunit</groupId>
-	    <artifactId>xmlunit</artifactId>
-	    <version>1.3</version>
+    <dependency>
+      <groupId>xmlunit</groupId>
+      <artifactId>xmlunit</artifactId>
+      <version>1.3</version>
       <optional>true</optional>
-	</dependency>
+    </dependency>
   </dependencies>
 
+  <scm>
+    <connection>scm:git:https://github.com/ndw/xmlcalabash1.git</connection>
+    <tag>${calabash.tag}</tag>
+  </scm>
+
   <build>
-    <sourceDirectory>${basedir}/target/calabash/src</sourceDirectory>
+    <sourceDirectory>${sources.dir}</sourceDirectory>
 
     <extensions>
       <extension>
@@ -106,29 +131,54 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-scm-plugin</artifactId>
+        <version>1.9.2</version>
+        <executions>
+          <execution>
+            <id>checkout</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>checkout</goal>
+            </goals>
+            <configuration>
+              <checkoutDirectory>${sources.dir}</checkoutDirectory>
+              <scmVersionType>tag</scmVersionType>
+              <scmVersion>${calabash.tag}</scmVersion>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-patch-plugin</artifactId>
+        <version>1.1.1</version>
+        <configuration>
+          <naturalOrderProcessing>true</naturalOrderProcessing>
+        </configuration>
+        <executions>
+          <execution>
+            <id>patch</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>apply</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
         <executions>
           <execution>
-            <id>download</id>
+            <id>build-jar</id>
             <phase>compile</phase>
             <goals>
               <goal>run</goal>
             </goals>
             <configuration>
               <target>
-                <property name="calabash.tmp.dir" value="${java.io.tmpdir}/calabash/${project.version}" />
-                <mkdir dir="${calabash.tmp.dir}" />
-                <get dest="${calabash.tmp.dir}/source.zip" src="${calabash.source.url}" usetimestamp="true" skipexisting="true" />
-                <unzip dest="${calabash.tmp.dir}" src="${calabash.tmp.dir}/source.zip" />
-                <move todir="${project.build.directory}/calabash">
-                  <fileset dir="${calabash.tmp.dir}">
-                    <include name="xmlcalabash1-*/**/*" />
-                  </fileset>
-                  <mapper type="regexp" from="^xmlcalabash1-[^/\\]*[/\\](.*)" to="\1" />
-                </move>
-                <property name="ant.build.javac.source" value="1.5" />
-                <property name="ant.build.javac.target" value="1.5" />
-                <ant dir="${project.build.directory}/calabash" target="jar" />
+                <property name="ant.build.javac.source" value="1.6" />
+                <property name="ant.build.javac.target" value="1.6" />
+                <ant dir="${sources.dir}" target="jar" />
               </target>
             </configuration>
           </execution>
@@ -140,7 +190,7 @@
             </goals>
             <configuration>
               <target>
-                <copy file="${project.build.directory}/calabash/calabash.jar" tofile="${project.build.directory}/${project.artifactId}-${project.version}.${project.packaging}" overwrite="true" verbose="true" />
+                <copy file="${sources.dir}/calabash.jar" tofile="${project.build.directory}/${project.artifactId}-${project.version}.${project.packaging}" overwrite="true" verbose="true" />
               </target>
             </configuration>
           </execution>
@@ -164,6 +214,63 @@
             </executions>
           </plugin>
           <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.9.1</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>javadoc</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <path id="build.classpath">
+                      <fileset dir="${sources.dir}/lib">
+                        <include name="*.jar"/>
+                      </fileset>
+                      <!-- <pathelement location="${sources.dir}/lib"/> -->
+                    </path>
+                    <javadoc destdir="${project.build.directory}/javadoc" classpathref="build.classpath">
+                      <fileset dir="${sources.dir}/src" defaultexcludes="yes">
+                        <include name="**"/>
+                        <exclude name="com/xmlcalabash/extensions/MetadataExtractor.java"/>
+                        <exclude name="com/xmlcalabash/extensions/DiTAA.java"/>
+                        <exclude name="com/xmlcalabash/extensions/PlantUML.java"/>
+                        <exclude name="com/xmlcalabash/extensions/DeltaXML.java"/>
+                        <exclude name="com/xmlcalabash/extensions/SendMail.java"/>
+                        <exclude name="com/xmlcalabash/extensions/xmlunit/Compare.java"/>
+                        <exclude name="com/xmlcalabash/extensions/marklogic/XCCAdhocQuery.java"/>
+                        <exclude name="com/xmlcalabash/extensions/marklogic/XCCInsertDocument.java"/>
+                        <exclude name="com/xmlcalabash/extensions/marklogic/XCCInvokeModule.java"/>
+                        <exclude name="com/xmlcalabash/extensions/Sparql.java"/>
+                        <exclude name="com/xmlcalabash/extensions/RDFa.java"/>
+                        <exclude name="com/xmlcalabash/extensions/RDFLoad.java"/>
+                        <exclude name="com/xmlcalabash/extensions/RDFStep.java"/>
+                        <exclude name="com/xmlcalabash/extensions/RDFStore.java"/>
+                        <exclude name="com/xmlcalabash/util/FoXEP.java"/>
+                        <exclude name="com/xmlcalabash/util/FoFOP.java"/>
+                        <exclude name="com/xmlcalabash/util/FoAH.java"/>
+                        <exclude name="com/xmlcalabash/util/CssAH.java"/>
+                        <exclude name="com/xmlcalabash/util/CssPrince.java"/>
+                        <exclude name="com/xmlcalabash/drivers/SaxonProblem.java"/>
+                      </fileset>
+                    </javadoc>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
             <executions>
               <execution>
@@ -175,6 +282,7 @@
                 <configuration>
                   <descriptors>
                     <descriptor>sources.xml</descriptor>
+                    <descriptor>javadoc.xml</descriptor>
                   </descriptors>
                 </configuration>
               </execution>

--- a/calabash/pom.xml
+++ b/calabash/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.daisy.libs</groupId>
   <artifactId>com.xmlcalabash</artifactId>
-  <version>1.0.23</version>
+  <version>1.0.23-p1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>XML Calabash</name>
@@ -107,7 +107,7 @@
 
   <scm>
     <connection>scm:git:https://github.com/ndw/xmlcalabash1.git</connection>
-    <tag>com.xmlcalabash-1.0.23</tag>
+    <tag>${calabash.tag}</tag>
   </scm>
 
   <build>

--- a/calabash/src/main/patches/001-unc-paths.patch
+++ b/calabash/src/main/patches/001-unc-paths.patch
@@ -1,0 +1,178 @@
+From 79a486fe6d7e584485d296b704ff9efe5b5973ea Mon Sep 17 00:00:00 2001
+From: Romain Deltour <rdeltour@gmail.com>
+Date: Tue, 23 Dec 2014 15:26:12 +0100
+Subject: [PATCH] Better URI-to-File conversion
+
+This should notably better handle UNC paths, which are often
+represented as file URIs with an authority component.
+---
+ src/com/xmlcalabash/extensions/RDFStore.java           |  5 ++++-
+ src/com/xmlcalabash/extensions/fileutils/Info.java     |  4 +++-
+ src/com/xmlcalabash/extensions/fileutils/Tempfile.java |  4 +++-
+ src/com/xmlcalabash/io/FileDataStore.java              | 14 ++++++++------
+ src/com/xmlcalabash/util/URIUtils.java                 |  7 +++++++
+ 5 files changed, 25 insertions(+), 9 deletions(-)
+
+diff --git src/com/xmlcalabash/extensions/RDFStore.java src/com/xmlcalabash/extensions/RDFStore.java
+index a419725..25a45d9 100644
+--- src/com/xmlcalabash/extensions/RDFStore.java
++++ src/com/xmlcalabash/extensions/RDFStore.java
+@@ -8,9 +8,12 @@ import com.xmlcalabash.core.XProcRuntime;
+ import com.xmlcalabash.runtime.XAtomicStep;
+ import com.xmlcalabash.util.Base64;
+ import com.xmlcalabash.util.TreeWriter;
++import com.xmlcalabash.util.URIUtils;
++
+ import net.sf.saxon.s9api.QName;
+ import net.sf.saxon.s9api.SaxonApiException;
+ import net.sf.saxon.s9api.XdmNode;
++
+ import org.apache.jena.riot.Lang;
+ import org.apache.jena.riot.RiotReader;
+ import org.apache.jena.riot.lang.LangRIOT;
+@@ -105,7 +108,7 @@ public class RDFStore extends RDFStep {
+                 baos = new ByteArrayOutputStream();
+                 outstr = baos;
+             } else if (href.getScheme().equals("file")) {
+-                File output = new File(href);
++                File output = URIUtils.toFile(href);
+ 
+                 File path = new File(output.getParent());
+                 if (!path.isDirectory()) {
+diff --git src/com/xmlcalabash/extensions/fileutils/Info.java src/com/xmlcalabash/extensions/fileutils/Info.java
+index b84e168..f0fcee4 100644
+--- src/com/xmlcalabash/extensions/fileutils/Info.java
++++ src/com/xmlcalabash/extensions/fileutils/Info.java
+@@ -13,6 +13,8 @@ import com.xmlcalabash.util.AxisNodes;
+ import com.xmlcalabash.util.MessageFormatter;
+ import com.xmlcalabash.util.TreeWriter;
+ import com.xmlcalabash.util.S9apiUtils;
++import com.xmlcalabash.util.URIUtils;
++
+ import net.sf.saxon.s9api.QName;
+ import net.sf.saxon.s9api.SaxonApiException;
+ import net.sf.saxon.s9api.XdmNode;
+@@ -90,7 +92,7 @@ public class Info extends DefaultStep {
+         tree.startDocument(step.getNode().getBaseURI());
+ 
+         if ("file".equals(uri.getScheme())) {
+-            File file = new File(uri.getPath());
++            File file = URIUtils.toFile(uri);
+ 
+             if (!file.exists()) {
+                 if (failOnError) {
+diff --git src/com/xmlcalabash/extensions/fileutils/Tempfile.java src/com/xmlcalabash/extensions/fileutils/Tempfile.java
+index dd366e8..10930bf 100644
+--- src/com/xmlcalabash/extensions/fileutils/Tempfile.java
++++ src/com/xmlcalabash/extensions/fileutils/Tempfile.java
+@@ -8,6 +8,8 @@ import com.xmlcalabash.core.XProcException;
+ import com.xmlcalabash.runtime.XAtomicStep;
+ import com.xmlcalabash.model.RuntimeValue;
+ import com.xmlcalabash.util.TreeWriter;
++import com.xmlcalabash.util.URIUtils;
++
+ import net.sf.saxon.s9api.QName;
+ import net.sf.saxon.s9api.SaxonApiException;
+ 
+@@ -72,7 +74,7 @@ public class Tempfile extends DefaultStep {
+         if (!"file".equals(uri.getScheme())) {
+             throw new XProcException(step.getNode(), "Only file: scheme URIs are supported by the tempfile step.");
+         } else {
+-            file = new File(uri.getPath());
++            file = URIUtils.toFile(uri);
+         }
+ 
+         if (!file.isDirectory()) {
+diff --git src/com/xmlcalabash/io/FileDataStore.java src/com/xmlcalabash/io/FileDataStore.java
+index 8433562..d0a7270 100644
+--- src/com/xmlcalabash/io/FileDataStore.java
++++ src/com/xmlcalabash/io/FileDataStore.java
+@@ -21,6 +21,8 @@
+ package com.xmlcalabash.io;
+ 
+ import com.xmlcalabash.core.XProcException;
++import com.xmlcalabash.util.URIUtils;
++
+ import org.slf4j.Logger;
+ import org.slf4j.LoggerFactory;
+ 
+@@ -67,7 +69,7 @@ public class FileDataStore implements DataStore {
+ 		URI baseURI = URI.create(base);
+ 		URI uri = baseURI.resolve(href);
+ 		if ("file".equalsIgnoreCase(uri.getScheme())) {
+-			File file = new File(uri);
++			File file = URIUtils.toFile(uri);
+ 			String suffix = getFileSuffixFromType(media);
+ 			if (file.isDirectory() || uri.getPath().endsWith("/")) {
+ 				if (!file.isDirectory() && !file.mkdirs()) {
+@@ -114,7 +116,7 @@ public class FileDataStore implements DataStore {
+ 		URI baseURI = URI.create(base);
+ 		URI uri = baseURI.resolve(href);
+ 		if ("file".equalsIgnoreCase(uri.getScheme())) {
+-			File file = new File(uri);
++		        File file = URIUtils.toFile(uri);
+ 			String type = getContentTypeFromName(file.getName());
+             if (overrideContentType != null) {
+                 type = overrideContentType;
+@@ -136,7 +138,7 @@ public class FileDataStore implements DataStore {
+ 		URI baseURI = URI.create(base);
+ 		URI uri = baseURI.resolve(href);
+ 		if ("file".equalsIgnoreCase(uri.getScheme())) {
+-			File file = new File(uri);
++		        File file = URIUtils.toFile(uri);
+ 			String type;
+ 			if (file.isFile()) {
+ 				type = getContentTypeFromName(file.getName());
+@@ -157,7 +159,7 @@ public class FileDataStore implements DataStore {
+ 		URI baseURI = URI.create(base);
+ 		URI uri = baseURI.resolve(href);
+ 		if ("file".equalsIgnoreCase(uri.getScheme())) {
+-			File file = new File(uri);
++		        File file = URIUtils.toFile(uri);
+ 
+             if (!file.canRead()) {
+                 throw XProcException.stepError(12);
+@@ -186,7 +188,7 @@ public class FileDataStore implements DataStore {
+ 		URI baseURI = URI.create(base);
+ 		URI uri = baseURI.resolve(href);
+ 		if ("file".equalsIgnoreCase(uri.getScheme())) {
+-			File file = new File(uri);
++		        File file = URIUtils.toFile(uri);
+ 			if (file.isDirectory()) {
+ 				return file.toURI();
+ 			} else if (file.exists()) {
+@@ -209,7 +211,7 @@ public class FileDataStore implements DataStore {
+ 		URI baseURI = URI.create(base);
+ 		URI uri = baseURI.resolve(href);
+ 		if ("file".equalsIgnoreCase(uri.getScheme())) {
+-			File file = new File(uri);
++		        File file = URIUtils.toFile(uri);
+ 			if (!file.exists()) {
+ 				throw new FileNotFoundException(file.toURI().toASCIIString());
+ 			} else if (!file.delete()) {
+diff --git src/com/xmlcalabash/util/URIUtils.java src/com/xmlcalabash/util/URIUtils.java
+index e5221a2..5a04a93 100644
+--- src/com/xmlcalabash/util/URIUtils.java
++++ src/com/xmlcalabash/util/URIUtils.java
+@@ -21,6 +21,7 @@
+ package com.xmlcalabash.util;
+ 
+ import com.xmlcalabash.core.XProcException;
++
+ import java.io.UnsupportedEncodingException;
+ import java.io.File;
+ import java.net.URI;
+@@ -100,4 +101,10 @@ public class URIUtils {
+         URI cwd = cwdAsURI();
+         return cwd.resolve(encode(localFn));
+     }
++    
++    public static File toFile(URI uri) {
++        if (!"file".equalsIgnoreCase(uri.getScheme()))
++            throw new IllegalStateException("Expecting a file URI");
++        return new File((uri.getAuthority() != null && uri.getAuthority().length() > 0)?"//"+uri.getAuthority()+uri.getPath():uri.getPath());
++    }
+ }
+-- 
+2.2.1
+

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <module>jing</module>
     <module>jnaerator</module>
     <module>jsslutils</module>
-    <module>jstyleparser</module>
+    <!-- <module>jstyleparser</module> -->
     <module>mysql</module>
     <module>saxon</module>
     <module>servlet-api</module>


### PR DESCRIPTION
 * Calabash sources are now fetched from Git via `maven-scm-plugin`
 * Patches in `src/main/patches` are applied
 * 1.0.23 is patched to fix the UNC path issue, see:
   https://github.com/ndw/xmlcalabash1/pull/185